### PR TITLE
Set 'raise_built' and 'raise_destroy' to let other mods know when you modify their entities.

### DIFF
--- a/ModMash/HeroTurrets/changelog.txt
+++ b/ModMash/HeroTurrets/changelog.txt
@@ -1,4 +1,19 @@
 ﻿---------------------------------------------------------------------------------------------------
+Version: 0.1.25
+  Bug Fixes:
+    - Added nil check for fluidboxes on entity died
+
+---------------------------------------------------------------------------------------------------
+Version: 0.1.25
+  Changes:
+    - Added option to record kill counts with items mined
+    - Killed entites leave the base turret not the ranked version, setting available
+    - Updated minable to mine correct item depending on kill count setting
+    - projectile and fluid ammo buffs now increase per rank, requires tech reset or new game
+  Bug Fixes:
+    - Added local for modifier descriptions, not for other modded entites as yet
+
+---------------------------------------------------------------------------------------------------
 Version: 0.1.24
   Changes:
     - Added artillery

--- a/ModMash/HeroTurrets/changelog.txt
+++ b/ModMash/HeroTurrets/changelog.txt
@@ -1,5 +1,10 @@
 ﻿---------------------------------------------------------------------------------------------------
-Version: 0.1.25
+Version: 0.1.27
+Date: 9/30/2020
+  Bug Fixes:
+    - Rolled in updates from Kingdud to let other mods know when we replace their entities. Reduces mod conflcits.
+---------------------------------------------------------------------------------------------------
+Version: 0.1.26
   Bug Fixes:
     - Added nil check for fluidboxes on entity died
 

--- a/ModMash/HeroTurrets/control.lua
+++ b/ModMash/HeroTurrets/control.lua
@@ -326,6 +326,7 @@ script.on_init(local_on_init)
 --[[Called subsequent times mod is loaded. Called each time except first instance]]
 script.on_load(function()
 	log("control.on_load")
+	
 --[[	if remote.interfaces["heroturrets"] == nil then
 		remote.add_interface("heroturrets",
 		{hero_1_detail = hero_1_detail,
@@ -340,6 +341,8 @@ script.on_load(function()
 	end)	
 
 script.on_configuration_changed(function(f) 
+
+	
 	if f.mod_changes["heroturrets"] == nil or f.mod_changes["heroturrets"].old_version == nil then
 		if heroturrets.force_configuration_change == true then
 			log("Forcing update to " .. game.active_mods["heroturrets"])
@@ -354,21 +357,18 @@ script.on_configuration_changed(function(f)
 	end
 
 	log("control.on_configuration_changed " .. f.mod_changes["heroturrets"].old_version .. " -> " .. f.mod_changes["heroturrets"].new_version)
-	global.heroturrets.shown_welcome = false 
-	if f.mod_changes["heroturrets"].old_version < "0.17.61" then	
-		log("control.on_configuration_changed(repair needed)")
-		local_on_init()
-		for k=1, #heroturrets.on_configuration_changed do local v = heroturrets.on_configuration_changed[k]		
-			v(f)
-		end
-		for k=1, #heroturrets.on_load do local v = heroturrets.on_load[k]		
-			v()
-		end 
-	else
-		for k=1, #heroturrets.on_configuration_changed do local v = heroturrets.on_configuration_changed[k]		
-			v(f)
-		end
+
+	for k=1, #heroturrets.on_configuration_changed do local v = heroturrets.on_configuration_changed[k]		
+		v(f)
 	end
+
+	--[[if f.mod_changes["heroturrets"].old_version < "0.1.25" then	
+		for i = 1, #game.players do local p = game.players[i]
+			p.force.reset_technologies() -- not working as hoped
+		end
+	
+	end]]
+	
 	end)
 
 
@@ -420,6 +420,7 @@ local local_on_damage = function(event)
 local local_item_pick_up = function(event)
 	if is_map_editor == true then return end
 	local stack = event.item_stack
+	if stack == nil then stack = event.buffer end
 	if stack ~= nil then				
 		for k=1, #heroturrets.on_pick_up do local v = heroturrets.on_pick_up[k]		
 			v(stack,event)

--- a/ModMash/HeroTurrets/info.json
+++ b/ModMash/HeroTurrets/info.json
@@ -1,6 +1,6 @@
 {
   "name": "heroturrets",
-  "version": "0.1.24",
+  "version": "0.1.26",
   "title": "HeroTurrets",
   "author": "PixelWhipped",
   "contact": "",

--- a/ModMash/HeroTurrets/info.json
+++ b/ModMash/HeroTurrets/info.json
@@ -1,6 +1,6 @@
 {
   "name": "heroturrets",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "title": "HeroTurrets",
   "author": "PixelWhipped",
   "contact": "",

--- a/ModMash/HeroTurrets/locale/en/locale.cfg
+++ b/ModMash/HeroTurrets/locale/en/locale.cfg
@@ -34,10 +34,14 @@ hero-turret-4=__hero-turret-4__
 [mod-setting-name]
 heroturrets-setting-level-up-modifier=Rank Modifier
 heroturrets-setting-level-buff-modifier=Rank Buff Modifier
+heroturrets-allow-ghost-rank=Allow ranked ghosts
+heroturrets-allow-blueprint-rank=Allow ranked blueprints
+heroturrets-kill-counter=Kill counter
 
 [mod-setting-description]
 heroturrets-setting-level-up-modifier=Alters the rank kill modifier
 heroturrets-setting-level-buff-modifier=Alters the buffs applied to the rank
+heroturrets-kill-counter=Exact will make turrest item-with-tags wich will result in many stacks in inventory due to each stack recoding different kill counts
 
 [item-group-name]
 
@@ -76,3 +80,13 @@ heroturrets-wiki-topic-3=Hero Turret Sargent
 heroturrets-wiki-topic-3-title=[font=heading-1]Hero Turret Sargent[/font]
 heroturrets-wiki-topic-4=Hero Turret General
 heroturrets-wiki-topic-4-title=[font=heading-1]Hero Turret General[/font]
+
+[modifier-description]
+hero-turret-1-for-gun-turret-attack-bonus=Gun turret damage: +__1__
+hero-turret-2-for-gun-turret-attack-bonus=Gun turret damage: +__1__
+hero-turret-3-for-gun-turret-attack-bonus=Gun turret damage: +__1__
+hero-turret-4-for-gun-turret-attack-bonus=Gun turret damage: +__1__
+hero-turret-1-for-flamethrower-turret-attack-bonus=Fire damage damage: +__1__
+hero-turret-2-for-flamethrower-turret-attack-bonus=Fire damage damage: +__1__
+hero-turret-3-for-flamethrower-turret-attack-bonus=Fire damage damage: +__1__
+hero-turret-4-for-flamethrower-turret-attack-bonus=Fire damage damage: +__1__

--- a/ModMash/HeroTurrets/prototypes/scripts/turrets.lua
+++ b/ModMash/HeroTurrets/prototypes/scripts/turrets.lua
@@ -45,8 +45,8 @@ local local_replace_turret = function(entity,recipe)
 		c = i.get_contents()		
 	end
 	
-	entity.destroy()
-	local new_entity = s.create_entity{name=recipe.name, position=p, force = f, direction = d, orientation = o}
+	entity.destroy({raise_destroy = true})
+	local new_entity = s.create_entity{name=recipe.name, position=p, force = f, direction = d, orientation = o, raise_built = true}
 	if h ~= mh then new_entity.health = h end
 	new_entity.kills = k
 	local inv = new_entity.get_inventory(defines.inventory.turret_ammo)

--- a/ModMash/HeroTurrets/settings.lua
+++ b/ModMash/HeroTurrets/settings.lua
@@ -16,5 +16,26 @@
 		minimum_value = 0,
 		maximum_value = 100,
 		order = "b"
-	}
+	},{
+		type = "bool-setting",
+		name = "heroturrets-allow-ghost-rank",
+		setting_type = "runtime-global",
+		default_value = false,
+		order = "c"
+	},
+	--[[{
+		type = "bool-setting",
+		name = "heroturrets-allow-blueprint-rank",
+		setting_type = "runtime-global",
+		default_value = false,
+		order = "d"
+	},]]
+	{
+		type = "string-setting",
+		name = "heroturrets-kill-counter",
+		setting_type = "startup",
+		default_value = "Fuzzy",
+		allowed_values = {"Fuzzy", "Exact"},
+		order = "e"
+	},
 })


### PR DESCRIPTION
One of my mods (Turret Shields) was having problems with yours (Hero Turrets). Long story short, you were not sending the raise_built and raise_destroy flags when you destroyed/built entities during a turret upgrade. These events allow other mods (mine) to know that something happened to their entities.

What was happening without these flags was that my array of turrets (keyed by unitID) was having the entities it referred to removed, but without the cleanup process my own code does to remove the shield entity when the turret goes away. This ended up meaning that upgraded turrets had no shields and there were lots of dangling shield entities on the map as more and more turrets got upgraded. These two changes completely remove this problem.

Only two lines of code were actually changed: 

`diff --git a/ModMash/HeroTurrets/prototypes/scripts/turrets.lua b/ModMash/HeroTurrets/prototypes/scripts/turrets.lua
index bac6fa1..f32c31f 100644
--- a/ModMash/HeroTurrets/prototypes/scripts/turrets.lua
+++ b/ModMash/HeroTurrets/prototypes/scripts/turrets.lua
@@ -45,8 +45,8 @@ local local_replace_turret = function(entity,recipe)
                c = i.get_contents()
        end

-       entity.destroy()
-       local new_entity = s.create_entity{name=recipe.name, position=p, force = f, direction = d, orientation = o}
+       entity.destroy({raise_destroy = true})
+       local new_entity = s.create_entity{name=recipe.name, position=p, force = f, direction = d, orientation = o, raise_built = true}
`

Everything else was bringing the code I got from forking your repo up to date with the code that was in the current release version of the mod (your repo has 1.24; the release version is 1.26).