### PR TITLE
Exclude Bigger Artillery Mod

### DIFF
--- a/ModMash/HeroTurrets/compatibility.lua
+++ b/ModMash/HeroTurrets/compatibility.lua
@@ -10,6 +10,8 @@ local turret_exclude_start = {
 	["se-meteor"] = true,
 	["vehicle-gun-turret"] = true,
 	["vehicle-rocket-turret"] = true,
+	["man-big-artillery-turret"] = true,
+	["big-artillery-turret"] = true,
 --	["obelisk-"] = true, --[[ Obelisk-of-light turrets ]]
 }
 


### PR DESCRIPTION
DoomSquirter noticed in [compatible with hero turrets?](https://mods.factorio.com/mod/bigger-artillery/discussion/622eaa1d0f06b7d278fa8f1f)
that the [Bigger Artillery](https://mods.factorio.com/mod/bigger-artillery) mod is not compatible with the HeroTurrets mod.

Please exclude the Bigger Artillery mod from your mod, because it depends on the entity name.