### PR TITLE
Hero Turrets - change dependencies for artwork mods

### DIFF
--- a/ModMash/HeroTurrets/changelog.txt
+++ b/ModMash/HeroTurrets/changelog.txt
@@ -1,5 +1,10 @@
 ﻿---------------------------------------------------------------------------------------------------
-Version: 1.1.20
+Version: 1.1.22
+Date: 2023-09-08
+  Changes:
+    - added recommended dependencies from Howitzer Art Patch PD to improve icons/art (honk)
+---------------------------------------------------------------------------------------------------
+Version: 1.1.21
 Date: 2022-02-23
   Changes:
     - Compatibility for SearchlightAssault mod setting Create in updates to change if turrets are created in final fixes or updates

--- a/ModMash/HeroTurrets/info.json
+++ b/ModMash/HeroTurrets/info.json
@@ -1,6 +1,6 @@
 {
   "name": "heroturrets",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "title": "HeroTurrets",
   "author": "PixelWhipped",
   "contact": "",
@@ -10,7 +10,11 @@
   "dependencies": [
     "base >= 1.1.0",
     "liborio >= 1.1.01",
-	"(?) Obelisks-of-light",
-	"(?) Factorio-Tiberium"
+    "(?) Obelisks-of-light",
+    "(?) Factorio-Tiberium",
+    "(?) HowitzerArtPatchPD",
+    "(?) ShockArtPatchPD",
+    "(?) SniperArtPatchPD",
+    "(?) ShotgunArtPatchPD"
   ]
 }


### PR DESCRIPTION
Add dependencies so Hero Turrets loads after some art mods