### PR TITLE
Please excluded bigger-artillery mod for compatibility

### DIFF
--- a/ModMash/HeroTurrets/compatibility.lua
+++ b/ModMash/HeroTurrets/compatibility.lua
@@ -10,6 +10,8 @@ local turret_exclude_start = {
 	["se-meteor"] = true,
 	["vehicle-gun-turret"] = true,
 	["vehicle-rocket-turret"] = true,
+	["man-big-artillery-turret"] = true,
+	["big-artillery-turret"] = true,
 --	["obelisk-"] = true, --[[ Obelisk-of-light turrets ]]
 }
 


### PR DESCRIPTION
Expected behavior:
Your mod should not replace the Big Bertha because it has a custom power connector that is deleted on destruction.

Actual behavior:
It replaces the Big Bertha and triggers the destruction of the power connector.

Reports:
https://mods.factorio.com/mod/bigger-artillery/discussion/64fcbb087c034199435ec393
https://mods.factorio.com/mod/heroturrets/discussion/64fcb81495e56b282f0681b7
https://mods.factorio.com/mod/bigger-artillery/discussion/622eaa1d0f06b7d278fa8f1f
https://mods.factorio.com/mod/heroturrets/discussion/62487bfee355e54bbb7b517a